### PR TITLE
fix: fixed tail handler not parsing events correctly

### DIFF
--- a/cloudflare/tail/events.go
+++ b/cloudflare/tail/events.go
@@ -60,9 +60,9 @@ type TraceItemGetWebSocketEvent struct {
 }
 
 type TraceLog struct {
-	Timestamp int64    `json:"timestamp,omitempty"`
-	Level     string   `json:"level,omitempty"`
-	Message   []string `json:"message"`
+	Timestamp int64  `json:"timestamp,omitempty"`
+	Level     string `json:"level,omitempty"`
+	Message   []any  `json:"message"`
 }
 
 type TraceException struct {

--- a/cloudflare/tail/events.go
+++ b/cloudflare/tail/events.go
@@ -96,15 +96,15 @@ type TraceItem struct {
 	ScriptVersion            *ScriptVersion                 `json:"scriptVersion,omitempty"`
 }
 
-func NewEvents(eventsJs js.Value) *[]TraceItem {
+func NewEvents(eventsJs js.Value) (*[]TraceItem, error) {
 	traces := []TraceItem{}
 
 	if !eventsJs.Truthy() {
-		return &traces
+		return &traces, nil
 	}
 
 	str := jsclass.JSON.Stringify(eventsJs)
-	json.Unmarshal([]byte(str.String()), &traces)
+	err := json.Unmarshal([]byte(str.String()), &traces)
 
-	return &traces
+	return &traces, err
 }

--- a/cloudflare/tail/handler.go
+++ b/cloudflare/tail/handler.go
@@ -55,7 +55,11 @@ func handler(eventsObj, envObj, ctxObj js.Value) error {
 		return err
 	}
 
-	events := NewEvents(eventsObj)
+	events, err := NewEvents(eventsObj)
+
+	if err != nil {
+		return err
+	}
 
 	return consumer(events)
 }

--- a/tests/unit/tail.spec.ts
+++ b/tests/unit/tail.spec.ts
@@ -260,10 +260,7 @@ describe("tail()", () => {
             timestamp: 1756036035775,
           },
           {
-            message: [
-              "exit code:",
-              "", // this was a number, but we are parsing only string values
-            ],
+            message: ["exit code:", 2],
             level: "warn",
             timestamp: 1756036035775,
           },

--- a/tests/unit/tail.spec.ts
+++ b/tests/unit/tail.spec.ts
@@ -1,114 +1,297 @@
+import worker from "$wrk/main";
 import {
-	createExecutionContext,
-	env,
-	waitOnExecutionContext,
+  createExecutionContext,
+  env,
+  waitOnExecutionContext,
 } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
-import worker from "$wrk/main";
 
 describe("tail()", () => {
-	let resultSaveInKV;
-	beforeAll(async () => {
-		const ctx = createExecutionContext();
-		const headers = new Headers();
-		headers.append("content-type", "application/json");
-		headers.append("x-custom-header", "true");
+  let resultSaveInKV;
+  beforeAll(async () => {
+    const ctx = createExecutionContext();
+    const headers = new Headers();
+    headers.append("content-type", "application/json");
+    headers.append("x-custom-header", "true");
 
-		const events = [
-			{
-				scriptName: "worker-producer",
-				truncated: false,
-				wallTime: 3713091757396727,
-				cpuTime: 5175330951149985,
-				dispatchNamespace: "dispatch-namespace",
-				entrypoint: "main.ts",
-				scriptTags: ["tags"],
-				executionModel: "exec-mode",
-				diagnosticsChannelEvents: [
-					{
-						message: "some",
-						timestamp: 1755357868138,
-						channel: "chan",
-					},
-				],
-				scriptVersion: {
-					id: "e3a18c84-4622-4a11-b703-455b38d50001",
-					message: "script-message",
-					tag: "01K2SQPW3AKDG2R0QZC2YNCSSB",
-				},
-				event: {
-					request: {
-						cf: null,
-						headers: headers,
-						method: "GET",
-						url: "http://service-url",
-					},
-					response: {
-						status: 200,
-					},
-				},
-				eventTimestamp: 1755357868138,
-				logs: [
-					{
-						level: "info",
-						timestamp: 1755357868138,
-						message: "start",
-					},
-					{
-						level: "info",
-						timestamp: 1755357868138,
-						message: "end",
-					},
-				],
-				exceptions: [],
-				outcome: "ok",
-			},
-		];
+    const events = [
+      {
+        wallTime: 0,
+        cpuTime: 0,
+        truncated: false,
+        executionModel: "stateless",
+        outcome: "ok",
+        scriptName: null,
+        diagnosticsChannelEvents: [],
+        exceptions: [],
+        logs: [
+          {
+            message: ["2025/08/24 08:47:15 this is a log 751000000"],
+            level: "log",
+            timestamp: 1756036035754,
+          },
+          {
+            message: ["2025/08/24 08:47:15 my error this is a error"],
+            level: "log",
+            timestamp: 1756036035771,
+          },
+          {
+            message: ["panic: this is a error"],
+            level: "log",
+            timestamp: 1756036035772,
+          },
+          {
+            message: [""],
+            level: "log",
+            timestamp: 1756036035772,
+          },
+          {
+            message: ["goroutine 9 [running]:"],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/errors.init.func1({0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/worker/pkg/fetchhandler/errors/get-with-error.go:19 +0x13",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "net/http.HandlerFunc.ServeHTTP(0x78d58, {0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: ["\t/usr/local/go/src/net/http/server.go:2294 +0x4"],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "net/http.(*ServeMux).ServeHTTP(0x2ffe60, {0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: ["\t/usr/local/go/src/net/http/server.go:2822 +0x2e"],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "github.com/Darckfast/workers-go/cloudflare/fetch.handler.func1()",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/cloudflare/fetch/handler.go:82 +0x4",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "created by github.com/Darckfast/workers-go/cloudflare/fetch.handler in goroutine 8",
+            ],
+            level: "log",
+            timestamp: 1756036035775,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/cloudflare/fetch/handler.go:72 +0x28",
+            ],
+            level: "log",
+            timestamp: 1756036035775,
+          },
+          {
+            message: ["exit code:", 2],
+            level: "warn",
+            timestamp: 1756036035775,
+          },
+        ],
+        eventTimestamp: 1756036035640,
+        event: {
+          request: {
+            url: "http://localhost:5173/error",
+            method: "GET",
+            headers: {
+              accept: "*/*",
+              "accept-encoding": "br, gzip",
+              "cf-connecting-ip": "127.0.0.1",
+              host: "localhost:5173",
+              "user-agent": "yaak",
+            },
+            cf: {
+              clientTcpRtt: 17,
+              requestHeaderNames: {},
+              httpProtocol: "HTTP/1.1",
+              tlsCipher: "AEAD-AES256-GCM-SHA384",
+            },
+          },
+          response: {
+            status: 500,
+          },
+        },
+      },
+    ];
 
-		await worker.tail(events, env, ctx);
-		await waitOnExecutionContext(ctx);
-		const request = new Request("http://example.com/tail");
-		const response: Response = await worker.fetch(request, env, ctx);
-		await waitOnExecutionContext(ctx);
-		resultSaveInKV = await response.json();
-	});
+    await worker.tail(events, env, ctx);
+    await waitOnExecutionContext(ctx);
+    const request = new Request("http://example.com/tail");
+    const response: Response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    resultSaveInKV = await response.json();
+  });
 
-	it("should serialize and proccess the event", async () => {
-		expect(JSON.parse(resultSaveInKV.result["tail:result"])).toStrictEqual([
-			{
-				scriptName: "worker-producer",
-				entrypoint: "main.ts",
-				event: {
-					response: { status: 200 },
-					request: {
-						headers: {
-							"Content-Type": ["application/json"],
-							"X-Custom-Header": ["true"],
-						},
-						method: "GET",
-						url: "http://service-url",
-					},
-				},
-				eventTimestamp: 1755357868138,
-				logs: [
-					{ timestamp: 1755357868138, level: "info", message: "start" },
-					{ timestamp: 1755357868138, level: "info", message: "end" },
-				],
-				diagnosticsChannelEvents: [
-					{ timestamp: 1755357868138, channel: "chan", message: "some" },
-				],
-				outcome: "ok",
-				cpuTime: 5175330951149985,
-				wallTime: 3713091757396727,
-				executionModel: "exec-mode",
-				scriptTags: ["tags"],
-				dispatchNamespace: "dispatch-namespace",
-				scriptVersion: {
-					id: "e3a18c84-4622-4a11-b703-455b38d50001",
-					tag: "01K2SQPW3AKDG2R0QZC2YNCSSB",
-					message: "script-message",
-				},
-			},
-		]);
-	});
+  it("should serialize and proccess the event", async () => {
+    expect(JSON.parse(resultSaveInKV.result["tail:result"])).toStrictEqual([
+      {
+        wallTime: 0,
+        cpuTime: 0,
+        truncated: false,
+        executionModel: "stateless",
+        outcome: "ok",
+        scriptName: "", // null becomes empty string
+        diagnosticsChannelEvents: [],
+        exceptions: [],
+        logs: [
+          {
+            message: ["2025/08/24 08:47:15 this is a log 751000000"],
+            level: "log",
+            timestamp: 1756036035754,
+          },
+          {
+            message: ["2025/08/24 08:47:15 my error this is a error"],
+            level: "log",
+            timestamp: 1756036035771,
+          },
+          {
+            message: ["panic: this is a error"],
+            level: "log",
+            timestamp: 1756036035772,
+          },
+          {
+            message: [""],
+            level: "log",
+            timestamp: 1756036035772,
+          },
+          {
+            message: ["goroutine 9 [running]:"],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/errors.init.func1({0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/worker/pkg/fetchhandler/errors/get-with-error.go:19 +0x13",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "net/http.HandlerFunc.ServeHTTP(0x78d58, {0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: ["\t/usr/local/go/src/net/http/server.go:2294 +0x4"],
+            level: "log",
+            timestamp: 1756036035773,
+          },
+          {
+            message: [
+              "net/http.(*ServeMux).ServeHTTP(0x2ffe60, {0xb3888, 0x47ab40}, 0x498140)",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: ["\t/usr/local/go/src/net/http/server.go:2822 +0x2e"],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "github.com/Darckfast/workers-go/cloudflare/fetch.handler.func1()",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/cloudflare/fetch/handler.go:82 +0x4",
+            ],
+            level: "log",
+            timestamp: 1756036035774,
+          },
+          {
+            message: [
+              "created by github.com/Darckfast/workers-go/cloudflare/fetch.handler in goroutine 8",
+            ],
+            level: "log",
+            timestamp: 1756036035775,
+          },
+          {
+            message: [
+              "\t/home/v/workers-go/cloudflare/fetch/handler.go:72 +0x28",
+            ],
+            level: "log",
+            timestamp: 1756036035775,
+          },
+          {
+            message: [
+              "exit code:",
+              "", // this was a number, but we are parsing only string values
+            ],
+            level: "warn",
+            timestamp: 1756036035775,
+          },
+        ],
+        eventTimestamp: 1756036035640,
+        event: {
+          request: {
+            url: "http://localhost:5173/error",
+            method: "GET",
+            headers: {
+              accept: "*/*",
+              "accept-encoding": "br, gzip",
+              "cf-connecting-ip": "127.0.0.1",
+              host: "localhost:5173",
+              "user-agent": "yaak",
+            },
+            cf: {
+              clientTcpRtt: 17,
+              requestHeaderNames: {},
+              httpProtocol: "HTTP/1.1",
+              tlsCipher: "AEAD-AES256-GCM-SHA384",
+            },
+          },
+          response: {
+            status: 500,
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/worker/pkg/fetchhandler/d1/read-from-d1.go
+++ b/worker/pkg/fetchhandler/d1/read-from-d1.go
@@ -29,12 +29,17 @@ var GET_D1 = func(w http.ResponseWriter, r *http.Request) {
 	result := db.QueryRow("SELECT id, data, created_at, updated_at FROM Testing WHERE id = ?", idi)
 
 	var a TestingRow
-
 	err := result.Scan(&a.Id, &a.Data, &a.CreatedAt, &a.UpdatedAt)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"data":  a,
-		"error": err,
-	})
+
+	if err != nil {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": err.Error(),
+		})
+	} else {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": a,
+		})
+	}
 }
 
 var PUT_D1 = func(w http.ResponseWriter, r *http.Request) {

--- a/worker/pkg/fetchhandler/errors/get-with-error.go
+++ b/worker/pkg/fetchhandler/errors/get-with-error.go
@@ -1,0 +1,20 @@
+//go:build js && wasm
+
+package errorshandler
+
+import (
+	"errors"
+	"log"
+	"net/http"
+	"time"
+)
+
+var GET_ERROR = func(w http.ResponseWriter, r *http.Request) {
+	log.Println("this is a log", time.Now().Nanosecond())
+
+	e := errors.New("this is a error")
+
+	log.Println("my error", e)
+
+	panic(e)
+}

--- a/worker/pkg/fetchhandler/routes.go
+++ b/worker/pkg/fetchhandler/routes.go
@@ -10,6 +10,7 @@ import (
 	httpd1 "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/d1"
 	httpdurableobject "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/durable-objects"
 	httpenv "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/env"
+	errorshandler "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/errors"
 	httpsimple "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/http"
 	httpkv "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/kv"
 	httpqueue "github.com/Darckfast/workers-go/worker/pkg/fetchhandler/queue"
@@ -60,6 +61,9 @@ func New() {
 	http.HandleFunc("GET /do", httpdurableobject.GET_DO)
 	// Env
 	http.HandleFunc("GET /env", httpenv.GET_ENV)
+
+	//Error
+	http.HandleFunc("GET /error", errorshandler.GET_ERROR)
 
 	/*
 	 * Fetch handler uses http.DefaulServeMux as default, calling this function is

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,6 +2,8 @@ name = "workers-go"
 main = "./main.ts"
 compatibility_date = "2025-08-12"
 
+tail_consumers = [{ service = "workers-go" }]
+
 [vars]
 API_HOST = "example.com"
 API_ACCOUNT_ID = "example_user"


### PR DESCRIPTION
## Changes
* fixed `tail` parse function, now we use `JSON.stringify()` instead of individuals `.Get()`
* updated `tail` test to use a real example
<!--
List the changes made in this PR
-->